### PR TITLE
increased WS range for Sarasa Term

### DIFF
--- a/bddy.js
+++ b/bddy.js
@@ -99,7 +99,8 @@ module.exports = function(ctx, the) {
 			main: $1,
 			o: tmpOTD,
 			mono: config.families[family].isMono || false,
-			pwid: config.families[family].isPWID || false
+			pwid: config.families[family].isPWID || false,
+			term: config.families[family].isTerm || false
 		});
 		await this.run("otfccbuild", tmpOTD, "-o", target, "-q");
 		await this.rm(tmpOTD);
@@ -112,7 +113,8 @@ module.exports = function(ctx, the) {
 			main: $1,
 			o: tmpOTD,
 			mono: config.families[family].isMono || false,
-			pwid: config.families[family].isPWID || false
+			pwid: config.families[family].isPWID || false,
+			term: config.families[family].isTerm || false
 		});
 		await this.run("otfccbuild", tmpOTD, "-o", target, "-q");
 		await this.rm(tmpOTD);

--- a/config.json
+++ b/config.json
@@ -38,6 +38,7 @@
 		"term": {
 			"isMono": true,
 			"latinGroup": "iosevka-term",
+			"isTerm": true,
 			"naming": {
 				"en_US": "Sarasa Term",
 				"zh_CN": "Sarasa Term",

--- a/make/punct/as.js
+++ b/make/punct/as.js
@@ -20,7 +20,7 @@ module.exports = async function makeFont(ctx, config, argv) {
 	await ctx.run(quadify, "a");
 	a.cmap_uvs = null;
 	for (let c in a.cmap) {
-		if (isKanji(c - 0) || isWestern(c - 0) || isKorean(c - 0) || isWS(c - 0)) {
+		if (isKanji(c - 0) || isWestern(c - 0) || isKorean(c - 0) || argv.term || isWS(c - 0)) {
 			a.cmap[c] = null;
 		}
 	}

--- a/make/punct/as.js
+++ b/make/punct/as.js
@@ -20,7 +20,7 @@ module.exports = async function makeFont(ctx, config, argv) {
 	await ctx.run(quadify, "a");
 	a.cmap_uvs = null;
 	for (let c in a.cmap) {
-		if (isKanji(c - 0) || isWestern(c - 0) || isKorean(c - 0) || argv.term || isWS(c - 0)) {
+		if (isKanji(c - 0) || isWestern(c - 0) || isKorean(c - 0) || isWS(c - 0, argv.term)) {
 			a.cmap[c] = null;
 		}
 	}

--- a/make/punct/common.js
+++ b/make/punct/common.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.isWestern = c => c <= 0x2000;
+exports.isWestern = c => c < 0x2000;
 exports.isKorean = c =>
 	(c >= 0xac00 && c <= 0xd7af) ||
 	(c >= 0x3130 && c <= 0x318f) ||
@@ -9,7 +9,9 @@ exports.isKorean = c =>
 	(c >= 0x3260 && c <= 0x327f) ||
 	(c >= 0xa960 && c <= 0xd7ff);
 
-exports.isWS = c => c >= 0x20a0 && c < 0x3000 && !(c >= 0x2e3a && c <= 0x2e3b);
+exports.isWS = function (c, isTerm = false) {
+	return c >= (isTerm ? 0x2000 : 0x20a0) && c < 0x3000 && !(c >= 0x2e3a && c <= 0x2e3b);
+}
 
 function deleteGPOS(font, gid) {
 	if (!font.GPOS) return;

--- a/make/punct/ws.js
+++ b/make/punct/ws.js
@@ -20,7 +20,7 @@ module.exports = async function makeFont(ctx, config, argv) {
 	await ctx.run(quadify, "a");
 	a.cmap_uvs = null;
 	for (let c in a.cmap) {
-		if (isKanji(c - 0) || isWestern(c - 0) || isKorean(c - 0) || !(argv.term || isWS(c - 0))) {
+		if (isKanji(c - 0) || isWestern(c - 0) || isKorean(c - 0) || !isWS(c - 0, argv.term)) {
 			a.cmap[c] = null;
 		}
 	}

--- a/make/punct/ws.js
+++ b/make/punct/ws.js
@@ -20,7 +20,7 @@ module.exports = async function makeFont(ctx, config, argv) {
 	await ctx.run(quadify, "a");
 	a.cmap_uvs = null;
 	for (let c in a.cmap) {
-		if (isKanji(c - 0) || isWestern(c - 0) || isKorean(c - 0) || !isWS(c - 0)) {
+		if (isKanji(c - 0) || isWestern(c - 0) || isKorean(c - 0) || !(argv.term || isWS(c - 0))) {
 			a.cmap[c] = null;
 		}
 	}


### PR DESCRIPTION
This is a fix for #19, now glyphs from Iosevka Term are always prioritized when build Sarasa Term (while Sarasa Mono remains untouched).

What it looks like now:

![2018-03-25 12 11 02](https://user-images.githubusercontent.com/2662820/37871654-a64906c0-3025-11e8-9f03-e8f8c4763473.png)

(The width of '…' (U+2026) also mentioned in #19 seems like another issue... I have only found it shown in triple width in Pages & Sublime Text, but not in Atom, Chrome etc.)