### PR TITLE
fix case and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm run build ttc
 
 instead, the files would be in `out/ttc` directory.
 
-Please note tnat you will need *a lot of* memory to create TTCs, due to the huge quantity of subfamily-orthography combinations.
+Please note that you will need *a lot of* memory to create TTCs, due to the huge quantity of subfamily-orthography combinations.
 
 ## What are the names?
 

--- a/config.json
+++ b/config.json
@@ -120,7 +120,7 @@
 		"TC": { "gbk": false, "big5": true, "jis": false, "korean": false },
 		"HC": { "gbk": false, "big5": true, "jis": false, "korean": false },
 		"CL": { "gbk": false, "big5": true, "jis": false, "korean": false },
-		"k": { "gbk": false, "big5": false, "jis": false, "korean": true }
+		"K": { "gbk": false, "big5": false, "jis": false, "korean": true }
 	},
 	"nameTupleSelector": {
 		"J": ["en_US", "ja_JP"],


### PR DESCRIPTION
The case issue makes text on icon “文字美” instead of “한글”.
![image](https://user-images.githubusercontent.com/14287996/66798439-8f24a680-ef40-11e9-95f5-b3fcff937f08.png)