### PR TITLE
Add GitHub link for Inter and Iosevka

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Please note that you will need *a lot of* memory to create TTCs, due to the huge
 ## What are the names?
 
 - Style dimension
-  - Latin/Greek/Cyrillic character set being Inter
+  - Latin/Greek/Cyrillic character set being [Inter](https://github.com/rsms/inter)
     - Quotes (`“”`) are full width —— **Gothic**
     - Quotes (`“”`) are narrow —— **UI**
-  - Latin/Greek/Cyrillic character set being Iosevka
+  - Latin/Greek/Cyrillic character set being [Iosevka](https://github.com/be5invis/Iosevka)
     - Em dashes (`——`) are full width —— **Mono**
     - Em dashes (`——`) are half width —— **Term**
     - No ligature, Em dashes (`——`) are half width —— **Fixed**


### PR DESCRIPTION
This PR add GitHub link for Inter and Iosevka:

- Inter: https://github.com/rsms/inter
- Iosevka: https://github.com/be5invis/Iosevka

I think it would be nice to have these links on README. Everyone can click on these links and quickly have idea about what is Inter and what is Iosevka, similar to the [Source Han Sans](https://github.com/adobe-fonts/source-han-sans) in the "Orthography dimension" section.