### PR TITLE
提前烘焙 `tnum`

### DIFF
--- a/make/pass1/index.mjs
+++ b/make/pass1/index.mjs
@@ -25,6 +25,9 @@ async function pass(argv) {
 
 	if (main.head.unitsPerEm !== 1000) CliProc.rebaseFont(main, 1000);
 
+	// Bake tnum for UI
+	if (argv.tnum) bakeFeature("tnum", main, c => c !== 0x2d);
+
 	if (argv.latinCfg?.bakeFeatures) {
 		for (const feature of argv.latinCfg.bakeFeatures) {
 			const filter = feature.range
@@ -42,9 +45,6 @@ async function pass(argv) {
 
 	// Drop enclosed alphanumerics and PUA
 	if (!argv.mono) dropCharacters(main, c => isEnclosedAlphanumerics(c) || isPua(c));
-
-	// Bake tnum for UI
-	if (argv.tnum) bakeFeature("tnum", main, c => c !== 0x2d);
 
 	if (argv.italize) {
 		italize(as, +9.4);


### PR DESCRIPTION
将 `tnum` 烘焙移到配置文件定义的 `bakeFeatures` 之前，使得在 config.json 中添加 `cvxx` 烘焙时，可以调用等宽变体数字。